### PR TITLE
remove `nonvoid_storage` usage from `when_all.h`

### DIFF
--- a/src/include/mp-coro/when_all.h
+++ b/src/include/mp-coro/when_all.h
@@ -115,8 +115,8 @@ decltype(auto) make_all_results(T&& container)
         (..., tasks.get());
       }
       else {
-        using ret_type = std::tuple<remove_rvalue_reference_t<decltype(std::forward<Tasks>(tasks).nonvoid_get())>...>;
-        return ret_type(std::forward<Tasks>(tasks).nonvoid_get()...);
+        using ret_type = std::tuple<remove_rvalue_reference_t<decltype(std::forward<Tasks>(tasks).get())>...>;
+        return ret_type(std::forward<Tasks>(tasks).get()...);
       }
     }, std::forward<T>(container));
   }


### PR DESCRIPTION
Hello, I was one of the volunteers from the university where you gave the c++20 coroutines workshop in Madrid. I got some free time now :sunglasses: 

I saw that the last commit in this repo removed the nonvoid storage. `when_all.h` still had a reference to `nonvoid_get()` and it failed to compile the examples. Here's the fix :)